### PR TITLE
Add Atlas Cloud LLM provider

### DIFF
--- a/backend/app/services/llm/provider_bootstrap.py
+++ b/backend/app/services/llm/provider_bootstrap.py
@@ -32,5 +32,12 @@ def bootstrap_builtin_providers() -> None:
                 supported_categories=(ModelCategoryKey.text,),
                 default_base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
             ),
+            ProviderSpec(
+                key="atlascloud",
+                display_name="Atlas Cloud",
+                aliases=("Atlas Cloud", "atlascloud", "atlas_cloud", "atlas"),
+                supported_categories=(ModelCategoryKey.text,),
+                default_base_url="https://api.atlascloud.ai/v1",
+            ),
         ]
     )

--- a/backend/tests/test_llm_api_responses.py
+++ b/backend/tests/test_llm_api_responses.py
@@ -202,18 +202,24 @@ def test_list_supported_providers_returns_capability_matrix(client: TestClient) 
     assert body["code"] == 200
     assert isinstance(body["data"], list)
     keys = {item["key"] for item in body["data"]}
+    assert "atlascloud" in keys
     assert "openai" in keys
     assert "volcengine" in keys
     assert "aliyun_bailian" in keys
 
 
-def test_list_supported_providers_text_contains_aliyun_bailian(client: TestClient) -> None:
+def test_list_supported_providers_text_contains_openai_compatible_providers(
+    client: TestClient,
+) -> None:
     response = client.get("/api/v1/llm/providers/supported", params={"category": "text"})
     assert response.status_code == 200
     body = response.json()
     assert body["code"] == 200
-    keys = {item["key"] for item in (body["data"] or [])}
+    providers = {item["key"]: item for item in (body["data"] or [])}
+    keys = set(providers)
+    assert "atlascloud" in keys
     assert "aliyun_bailian" in keys
+    assert providers["atlascloud"]["default_base_url"] == "https://api.atlascloud.ai/v1"
 
 
 def test_list_supported_providers_can_filter_by_category(client: TestClient) -> None:

--- a/backend/tests/test_llm_manage.py
+++ b/backend/tests/test_llm_manage.py
@@ -172,6 +172,35 @@ async def test_create_model_rejects_unsupported_category_for_provider() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_model_allows_atlascloud_text_provider() -> None:
+    db, engine = await _build_session()
+    async with db:
+        await create_provider(
+            db,
+            body=ProviderCreate(
+                id="p-atlascloud",
+                name="Atlas Cloud",
+                base_url="https://api.atlascloud.ai/v1",
+                api_key="k",
+            ),
+        )
+
+        created = await create_model(
+            db,
+            body=ModelCreate(
+                id="m-atlascloud-text",
+                name="deepseek-ai/deepseek-v4-pro",
+                category=ModelCategoryKey.text,
+                provider_id="p-atlascloud",
+            ),
+        )
+
+        assert created.id == "m-atlascloud-text"
+        assert created.provider_id == "p-atlascloud"
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_update_model_rejects_switch_to_unsupported_provider_category_combo() -> None:
     db, engine = await _build_session()
     async with db:

--- a/backend/tests/test_llm_resolver.py
+++ b/backend/tests/test_llm_resolver.py
@@ -230,3 +230,11 @@ def test_resolve_effective_base_url_prefers_category_specific_url() -> None:
         == "https://video-gateway.example/v1"
     )
 
+
+def test_resolve_effective_base_url_uses_atlascloud_default_text_url() -> None:
+    provider = Provider(id="p-atlascloud", name="Atlas Cloud", base_url="", api_key="k")
+
+    assert (
+        resolve_effective_base_url(provider=provider, category=ModelCategoryKey.text)
+        == "https://api.atlascloud.ai/v1"
+    )


### PR DESCRIPTION
## Summary
- register Atlas Cloud as a built-in text LLM provider in the provider capability registry
- expose the default OpenAI-compatible base URL through `/providers/supported`
- add resolver and management tests for Atlas Cloud text model configuration

## Validation
- confirmed `deepseek-ai/deepseek-v4-pro` is present in the live Atlas Cloud model list with `display_console=true`
- confirmed Atlas Cloud's OpenAI-compatible chat endpoint responds through `https://api.atlascloud.ai/v1`

## Tests
- `uv run pytest tests/test_llm_api_responses.py tests/test_llm_manage.py tests/test_llm_resolver.py -q`
- live smoke test: `deepseek-ai/deepseek-v4-pro` returned `OK` through the OpenAI-compatible chat API
