### PR TITLE
feat(llm): add Novita as an OpenAI-compatible text provider

### DIFF
--- a/backend/app/services/llm/provider_bootstrap.py
+++ b/backend/app/services/llm/provider_bootstrap.py
@@ -32,5 +32,12 @@ def bootstrap_builtin_providers() -> None:
                 supported_categories=(ModelCategoryKey.text,),
                 default_base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
             ),
+            ProviderSpec(
+                key="novita",
+                display_name="Novita",
+                aliases=("novita", "novita_ai", "novita-ai"),
+                supported_categories=(ModelCategoryKey.text,),
+                default_base_url="https://api.novita.ai/openai/v1",
+            ),
         ]
     )

--- a/backend/tests/test_llm_api_responses.py
+++ b/backend/tests/test_llm_api_responses.py
@@ -205,6 +205,7 @@ def test_list_supported_providers_returns_capability_matrix(client: TestClient) 
     assert "openai" in keys
     assert "volcengine" in keys
     assert "aliyun_bailian" in keys
+    assert "novita" in keys
 
 
 def test_list_supported_providers_text_contains_aliyun_bailian(client: TestClient) -> None:

--- a/backend/tests/test_novita_provider.py
+++ b/backend/tests/test_novita_provider.py
@@ -1,0 +1,89 @@
+"""Unit tests for Novita provider registration and resolver behaviour."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.models.llm import ModelCategoryKey, Provider
+from app.services.llm.provider_bootstrap import bootstrap_builtin_providers
+from app.services.llm.provider_registry import (
+    _KEY_BY_ALIAS,
+    _LOCK,
+    _SPECS_BY_KEY,
+    get_provider_spec,
+    list_registered_providers,
+    resolve_provider_key_from_name,
+)
+from app.services.llm.provider_resolver import resolve_effective_base_url
+
+
+def _reset_registry() -> None:
+    with _LOCK:
+        _SPECS_BY_KEY.clear()
+        _KEY_BY_ALIAS.clear()
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry() -> None:
+    _reset_registry()
+    bootstrap_builtin_providers()
+    yield
+    _reset_registry()
+
+
+class TestNovitaRegistration:
+    def test_novita_is_registered(self) -> None:
+        spec = get_provider_spec("novita")
+        assert spec.key == "novita"
+
+    def test_novita_display_name(self) -> None:
+        spec = get_provider_spec("novita")
+        assert spec.display_name == "Novita"
+
+    def test_novita_default_base_url(self) -> None:
+        spec = get_provider_spec("novita")
+        assert spec.default_base_url == "https://api.novita.ai/openai/v1"
+
+    def test_novita_supports_text_category(self) -> None:
+        spec = get_provider_spec("novita")
+        assert ModelCategoryKey.text in spec.supported_categories
+
+    def test_novita_does_not_support_image_category(self) -> None:
+        spec = get_provider_spec("novita")
+        assert ModelCategoryKey.image not in spec.supported_categories
+
+    def test_novita_does_not_support_video_category(self) -> None:
+        spec = get_provider_spec("novita")
+        assert ModelCategoryKey.video not in spec.supported_categories
+
+    def test_novita_requires_api_key(self) -> None:
+        spec = get_provider_spec("novita")
+        assert spec.requires_api_key is True
+
+    def test_novita_resolve_by_alias(self) -> None:
+        assert resolve_provider_key_from_name("novita_ai") == "novita"
+        assert resolve_provider_key_from_name("novita-ai") == "novita"
+
+    def test_novita_resolve_lowercase(self) -> None:
+        assert resolve_provider_key_from_name("Novita") == "novita"
+
+    def test_novita_appears_in_text_provider_list(self) -> None:
+        keys = [p.key for p in list_registered_providers(category=ModelCategoryKey.text)]
+        assert "novita" in keys
+
+    def test_novita_not_in_image_provider_list(self) -> None:
+        keys = [p.key for p in list_registered_providers(category=ModelCategoryKey.image)]
+        assert "novita" not in keys
+
+    def test_novita_not_in_video_provider_list(self) -> None:
+        keys = [p.key for p in list_registered_providers(category=ModelCategoryKey.video)]
+        assert "novita" not in keys
+
+
+def test_resolve_effective_base_url_uses_novita_default_text_url() -> None:
+    provider = Provider(id="p-novita", name="Novita", base_url="", api_key="k")
+
+    assert (
+        resolve_effective_base_url(provider=provider, category=ModelCategoryKey.text)
+        == "https://api.novita.ai/openai/v1"
+    )


### PR DESCRIPTION

## Summary

Adds Novita as a new LLM provider option, following the same pattern as the existing `aliyun_bailian` OpenAI-compatible provider.

## Changes

- Register a `novita` `ProviderSpec` in `backend/app/services/llm/provider_bootstrap.py` (aliases `novita`, `novita_ai`, `novita-ai`; text category; default base URL `https://api.novita.ai/openai/v1`).
- Add `novita` to the capability matrix assertion in `backend/tests/test_llm_api_responses.py`.
- Add `backend/tests/test_novita_provider.py` covering registration, alias resolution, category scoping, and default base URL resolution.

## Verification

- `uv run --directory backend pytest tests/test_novita_provider.py tests/test_llm_api_responses.py tests/test_llm_manage.py tests/test_llm_resolver.py` — 38 passed.
- `uv run --directory backend pylint app/services/llm/provider_bootstrap.py` — 10.00/10.
- Manually exercised the provider through the repository's own runtime path (`Provider` → `provider_resolver` → `langchain_openai.ChatOpenAI`) against the live Novita API; got a real completion back with the expected model name and stop reason.
